### PR TITLE
Matrix constructor takes floating point numbers (fixes #55)

### DIFF
--- a/source/opencv2/core/opencv_type.cc
+++ b/source/opencv2/core/opencv_type.cc
@@ -207,7 +207,7 @@ PHP_METHOD(opencv_scalar, __construct)
         RETURN_NULL();
     }
     opencv_scalar_object *obj = Z_PHP_SCALAR_OBJ_P(getThis());
-    Scalar scalar = Scalar((int)value1, (int)value2, (int)value3, (int)value4);
+    Scalar scalar = Scalar(value1, value2, value3, value4);
     obj->scalar = new Scalar(scalar);
     opencv_scalar_update_property_by_c_scalar(getThis(), obj->scalar);
 }

--- a/tests/mat.phpt
+++ b/tests/mat.phpt
@@ -48,6 +48,8 @@ var_dump($mat_data3->dataAt(3));
 $mat_data4 = Mat::ones(4,2,CV_8UC1);
 var_dump($mat_data4->total());
 
+# Issue #55
+(new Scalar(78.4263377603, 87.7689143744, 114.895847746))->print();
 ?>
 --EXPECT--
 object(CV\Mat)#2 (5) {
@@ -184,3 +186,5 @@ array(4) {
  [  1,   1,   1,   1,   1,   1,   1,   1,   1,   1]]
 int(4)
 int(8)
+[78.4263, 87.7689, 114.896, 0]
+


### PR DESCRIPTION
Includes test case for it. Tested on php8.2 and php7.4 under Debian Linux.